### PR TITLE
release: v1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,52 +1,6 @@
-# EmDash Starter Template (Cloudflare)
+# CUT — Sitio Institucional
 
-A general-purpose starting point for building sites with [EmDash](https://github.com/emdash-cms/emdash) on Cloudflare Workers. Includes posts, pages, categories, and tags with minimal styling -- designed as a base you can build on rather than a finished theme.
+Documentación disponible en [`docs/`](./docs/):
 
-[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/emdash-cms/templates/tree/main/starter-cloudflare)
-
-## What's Included
-
-- Posts with category and tag archives
-- Static pages via slug routing
-- Seed data with demo content
-- D1 database and R2 storage pre-configured
-- Dark/light mode support
-
-## Pages
-
-| Page | Route |
-|---|---|
-| Homepage | `/` |
-| All posts | `/posts` |
-| Single post | `/posts/:slug` |
-| Category archive | `/category/:slug` |
-| Tag archive | `/tag/:slug` |
-| Static pages | `/:slug` |
-| 404 | fallback |
-
-## Infrastructure
-
-- **Runtime:** Cloudflare Workers
-- **Database:** D1
-- **Storage:** R2
-- **Framework:** Astro with `@astrojs/cloudflare`
-
-## Local Development
-
-```bash
-pnpm install
-pnpm bootstrap
-pnpm dev
-```
-
-## Deploying
-
-```bash
-pnpm deploy
-```
-
-Or click the deploy button above to set up the project in your Cloudflare account.
-
-## See Also
-
-- [EmDash documentation](https://github.com/emdash-cms/emdash/tree/main/docs)
+- [Guía para desarrolladores](./docs/desarrolladores.md)
+- [Guía para editores de contenido](./docs/editores.md)

--- a/docs/desarrolladores.md
+++ b/docs/desarrolladores.md
@@ -1,0 +1,201 @@
+# Guía para desarrolladores — CUT
+
+Sitio institucional de CUT (Centro Universitario Tlacaélel), construido con [EmDash CMS](https://github.com/emdash-cms/emdash) sobre Astro y desplegado en Cloudflare Workers.
+
+---
+
+## Stack
+
+| Capa | Tecnología |
+|---|---|
+| Framework | Astro (SSR, `output: "server"`) |
+| CMS | EmDash |
+| Runtime | Cloudflare Workers |
+| Base de datos | Cloudflare D1 (SQLite) |
+| Almacenamiento | Cloudflare R2 |
+| Caché de sesión | Cloudflare KV |
+
+---
+
+## Configuración local
+
+### Requisitos
+
+- Node.js 22+
+- Cuenta en Cloudflare (solo para deploy)
+
+### Primer arranque
+
+```bash
+git clone <repo>
+cd cut-2026
+npm install
+npx emdash dev
+```
+
+`emdash dev` hace tres cosas: corre migraciones sobre la base de datos local, aplica el seed, y arranca el servidor de Astro.
+
+- Sitio: http://localhost:4321
+- Admin: http://localhost:4321/_emdash/admin
+
+Para el admin en local no se requiere contraseña — el bypass de desarrollo está activo automáticamente.
+
+### Regenerar tipos TypeScript
+
+Después de modificar el esquema (colecciones o campos), regenera los tipos:
+
+```bash
+npx emdash types
+```
+
+Escribe `emdash-env.d.ts` en la raíz. Este archivo se auto-genera — no lo edites a mano.
+
+---
+
+## Estructura del proyecto
+
+```
+cut-2026/
+├── src/
+│   ├── pages/          # Rutas Astro (todas SSR)
+│   ├── layouts/        # Base.astro y layouts de sección
+│   ├── components/     # Componentes React y Astro
+│   ├── styles/         # CSS global y tokens de diseño
+│   └── utils/          # Helpers (resolve-entry-page, site-identity, etc.)
+├── seed/
+│   └── seed.json       # Esquema de colecciones + contenido demo
+├── docs/               # Esta documentación
+├── public/             # Assets estáticos
+├── astro.config.mjs    # Configuración de Astro + integración EmDash
+└── wrangler.jsonc      # Configuración de Cloudflare Workers
+```
+
+### Reglas importantes
+
+- **Todas las páginas son SSR.** No uses `getStaticPaths()` para contenido del CMS.
+- Los campos de imagen son objetos `{ src, alt }`, no strings. Usa `<Image image={...} />` de `"emdash/ui"`.
+- `entry.id` = slug (para URLs). `entry.data.id` = ULID de base de datos (para llamadas API como `getEntryTerms`).
+- Siempre llama `Astro.cache.set(cacheHint)` en páginas que consultan contenido.
+
+---
+
+## Colecciones y esquema
+
+El esquema vive en `seed/seed.json`. Define colecciones, campos, taxonomías y menús.
+
+### Colecciones actuales
+
+| Slug | Label | Descripción |
+|---|---|---|
+| `posts` | Noticias | Noticias e artículos |
+| `pages` | Páginas | Páginas estáticas del CMS |
+| `licenciaturas` | Licenciaturas | Programas de licenciatura |
+| `maestrias` | Maestrías | Programas de posgrado |
+| `announcements` | Anuncios | Avisos temporales |
+| `aviso_destacado` | Aviso Destacado | Hero highlight de la home |
+| `library_collections` | Acervos Bibliotecarios | Colecciones de biblioteca |
+
+### Agregar una colección nueva
+
+**Opción A — vía CLI (solo para producción o instancias remotas):**
+
+```bash
+npx emdash schema create mi_coleccion --label "Mi Colección" \
+  --url https://cut.com.mx
+
+npx emdash schema add-field mi_coleccion titulo --type string --label "Título" --required \
+  --url https://cut.com.mx
+```
+
+**Opción B — vía seed (recomendada para desarrollo):**
+
+1. Agrega la colección y sus campos en `seed/seed.json` dentro de `"collections"`.
+2. Agrega contenido demo en `seed/seed.json` dentro de `"content"`.
+3. Valida: `npx emdash seed seed/seed.json --validate`
+4. Reinicia el servidor para aplicar migraciones.
+
+> Tipos de campo disponibles: `string`, `text`, `number`, `integer`, `boolean`, `datetime`, `image`, `reference`, `portableText`, `json`.
+
+---
+
+## Consultar contenido en páginas
+
+```typescript
+import { getEmDashCollection, getEmDashEntry } from "emdash"
+
+// Lista
+const { entries, cacheHint } = await getEmDashCollection("posts", {
+  orderBy: { published_at: "desc" },
+  limit: 10,
+})
+Astro.cache.set(cacheHint)
+
+// Entrada única por slug
+const { entry, cacheHint } = await getEmDashEntry("posts", Astro.params.slug)
+if (!entry) return Astro.redirect("/404")
+Astro.cache.set(cacheHint)
+```
+
+---
+
+## Deploy a Cloudflare
+
+### Prerequisitos
+
+- `CLOUDFLARE_API_TOKEN` y `CLOUDFLARE_ACCOUNT_ID` configurados (en CI o `.dev.vars` local).
+- Base de datos D1 creada: `npx wrangler d1 create cut-2026` y el ID registrado en `wrangler.jsonc`.
+
+### Deploy manual
+
+```bash
+npm run deploy
+# equivalente a: astro build && wrangler deploy
+```
+
+### Deploy automático (CI)
+
+El workflow `.github/workflows/deploy-preview.yml` despliega automáticamente en cada PR a `main`.
+
+El merge a `main` **no despliega automáticamente** — se hace manualmente o se puede agregar un workflow de deploy en `push` a `main`.
+
+### Aplicar seed en producción
+
+El seed aplica el esquema y el contenido demo. Solo es necesario en el primer setup o después de un reset de la base de datos:
+
+```bash
+# No hay comando directo para D1 remota vía seed.
+# Usa el CLI de EmDash para crear colecciones y contenido en remoto:
+npx emdash schema create ... --url https://cut.com.mx
+npx emdash content create ... --url https://cut.com.mx
+```
+
+---
+
+## Variables de entorno
+
+| Variable | Dónde | Descripción |
+|---|---|---|
+| `EMDASH_SECRET` | Workers secret | Clave de cifrado de sesiones |
+| `CLOUDFLARE_API_TOKEN` | CI / `.dev.vars` | Token para deploy con Wrangler |
+| `CLOUDFLARE_ACCOUNT_ID` | CI / `.dev.vars` | ID de cuenta Cloudflare |
+
+Para desarrollo local, crea `.dev.vars` en la raíz:
+
+```bash
+EMDASH_SECRET=cualquier-cadena-larga-aqui
+```
+
+---
+
+## Comandos frecuentes
+
+```bash
+npx emdash dev                              # Servidor local con migraciones
+npx emdash types                            # Regenerar tipos TS
+npx emdash seed seed/seed.json --validate   # Validar seed sin aplicar
+npx emdash content list posts               # Listar contenido local
+npx emdash whoami                           # Ver sesión activa
+npm run deploy                              # Build + deploy a Cloudflare
+npm run typecheck                           # Type check con astro check
+npm run lint                                # Lint con oxlint
+```

--- a/docs/editores.md
+++ b/docs/editores.md
@@ -1,0 +1,122 @@
+# Guía para editores de contenido — CUT
+
+Panel de administración: **https://cut.com.mx/_emdash/admin**
+
+---
+
+## Acceso
+
+1. Abre el panel en la URL de arriba.
+2. Inicia sesión con tu correo institucional.
+3. Si es tu primera vez, solicita al equipo técnico que te den acceso de editor.
+
+---
+
+## Colecciones disponibles
+
+| Colección | Qué contiene |
+|---|---|
+| **Posts** | Noticias e artículos institucionales |
+| **Pages** | Páginas estáticas (aviso de privacidad, reglamento, etc.) |
+| **Licenciaturas** | Programas de licenciatura |
+| **Maestrías** | Programas de posgrado |
+| **Anuncios** | Avisos temporales con fecha de inicio y fin |
+| **Aviso Destacado** | El aviso principal que aparece en el hero de la página de inicio |
+| **Acervos Bibliotecarios** | Colecciones del acervo de la biblioteca |
+
+---
+
+## Crear contenido nuevo
+
+1. En el panel lateral izquierdo, selecciona la colección.
+2. Haz clic en **Nuevo** (o el botón equivalente).
+3. Llena los campos requeridos (marcados con `*`).
+4. Haz clic en **Guardar borrador** para guardar sin publicar, o **Publicar** para que sea visible en el sitio.
+
+> El contenido publicado aparece en el sitio en segundos. Los borradores no son visibles para los visitantes.
+
+---
+
+## Editar contenido existente
+
+1. Selecciona la colección en el panel lateral.
+2. Busca el elemento por título o usa el buscador.
+3. Haz clic sobre él para abrir el editor.
+4. Realiza los cambios y haz clic en **Publicar**.
+
+---
+
+## Colecciones con campos especiales
+
+### Posts (Noticias)
+
+| Campo | Descripción |
+|---|---|
+| `title` | Título de la noticia |
+| `body` | Contenido principal (editor de texto enriquecido) |
+| `excerpt` | Resumen corto que aparece en listados |
+| `image` | Imagen principal (sube desde tu computadora) |
+| `category` | Categoría del artículo |
+
+### Anuncios
+
+Los anuncios aparecen como banners o alertas en el sitio. Tienen fechas de vigencia:
+
+| Campo | Descripción |
+|---|---|
+| `title` | Texto del anuncio |
+| `cta_label` | Texto del botón (ej. "Ver más") |
+| `cta_href` | URL a la que lleva el botón |
+| `start_date` | Fecha de inicio de vigencia |
+| `end_date` | Fecha de fin de vigencia |
+
+### Aviso Destacado
+
+Solo se muestra el más reciente (por fecha) en el hero de la página de inicio.
+
+| Campo | Descripción |
+|---|---|
+| `title` | Título principal del aviso |
+| `kicker` | Etiqueta pequeña arriba del título (ej. "Aviso Académico") |
+| `meta` | Descripción corta |
+| `cta_label` | Texto del botón |
+| `cta_href` | URL del botón |
+| `start_date` | Fecha del evento o anuncio |
+
+---
+
+## Subir imágenes
+
+1. En el panel lateral, busca la sección **Medios** (o haz clic en el campo de imagen dentro del editor de contenido).
+2. Arrastra tu archivo o haz clic en **Subir**.
+3. Agrega un texto alternativo (`alt`) descriptivo — es importante para accesibilidad.
+4. Confirma y la imagen queda disponible para usar en cualquier colección.
+
+**Formatos soportados:** JPG, PNG, WebP, SVG.  
+**Recomendación:** usa imágenes en WebP de menos de 1 MB para mejor rendimiento.
+
+---
+
+## Menús de navegación
+
+Los menús del sitio (navegación principal, footer) se gestionan desde la sección **Menús** del panel.
+
+1. Selecciona el menú a editar (ej. `primary`, `footer`).
+2. Agrega, elimina o reordena los elementos.
+3. Guarda los cambios — se reflejan en el sitio de inmediato.
+
+---
+
+## Preguntas frecuentes
+
+**¿Cuánto tarda en verse el contenido publicado en el sitio?**  
+Normalmente menos de un minuto.
+
+**¿Puedo recuperar una versión anterior?**  
+Sí. Las colecciones con revisiones (Posts, Aviso Destacado, Anuncios) guardan historial. Busca la opción de **Revisiones** dentro del editor.
+
+**¿Qué pasa si borro algo por error?**  
+El borrado es suave — el contenido se marca como eliminado pero no se destruye. Contacta al equipo técnico para restaurarlo.
+
+**¿Puedo programar una publicación para una fecha futura?**  
+Sí. En el editor, usa la opción **Programar** en lugar de **Publicar** e indica la fecha y hora.

--- a/emdash-env.d.ts
+++ b/emdash-env.d.ts
@@ -3,9 +3,9 @@
 
 /// <reference types="emdash/locals" />
 
-import type { ContentBylineCredit, PortableTextBlock } from "emdash";
+import type { ContentBylineCredit, TaxonomyTerm, PortableTextBlock } from "emdash";
 
-export interface Anuncios {
+export interface Announcement {
   id: string;
   slug: string | null;
   status: string;
@@ -14,18 +14,19 @@ export interface Anuncios {
   cta_href?: string;
   start_date?: string;
   end_date?: string;
-  image?: { id: string; src?: string; alt?: string; width?: number; height?: number };
+  image?: { id: string; src?: string; alt?: string; width?: number; height?: number; provider?: string; previewUrl?: string; meta?: Record<string, unknown> };
   createdAt: Date;
   updatedAt: Date;
   publishedAt: Date | null;
   bylines?: ContentBylineCredit[];
+  terms?: Record<string, TaxonomyTerm[]>;
 }
 
 export interface AvisoDestacado {
   id: string;
   slug: string | null;
   status: string;
-  title?: string;
+  title: string;
   kicker?: string;
   meta?: string;
   cta_label?: string;
@@ -35,9 +36,10 @@ export interface AvisoDestacado {
   updatedAt: Date;
   publishedAt: Date | null;
   bylines?: ContentBylineCredit[];
+  terms?: Record<string, TaxonomyTerm[]>;
 }
 
-export interface Acervo {
+export interface LibraryCollection {
   id: string;
   slug: string | null;
   status: string;
@@ -50,6 +52,7 @@ export interface Acervo {
   updatedAt: Date;
   publishedAt: Date | null;
   bylines?: ContentBylineCredit[];
+  terms?: Record<string, TaxonomyTerm[]>;
 }
 
 export interface Licenciatura {
@@ -58,7 +61,7 @@ export interface Licenciatura {
   status: string;
   title: string;
   order?: number;
-  featured_image?: { id: string; src?: string; alt?: string; width?: number; height?: number };
+  featured_image?: { id: string; src?: string; alt?: string; width?: number; height?: number; provider?: string; previewUrl?: string; meta?: Record<string, unknown> };
   excerpt?: string;
   content?: PortableTextBlock[];
   duration?: string;
@@ -70,6 +73,7 @@ export interface Licenciatura {
   updatedAt: Date;
   publishedAt: Date | null;
   bylines?: ContentBylineCredit[];
+  terms?: Record<string, TaxonomyTerm[]>;
 }
 
 export interface Maestria {
@@ -77,20 +81,21 @@ export interface Maestria {
   slug: string | null;
   status: string;
   title: string;
-  featured_image?: { id: string; src?: string; alt?: string; width?: number; height?: number };
+  featured_image?: { id: string; src?: string; alt?: string; width?: number; height?: number; provider?: string; previewUrl?: string; meta?: Record<string, unknown> };
   excerpt?: string;
   content?: PortableTextBlock[];
   duration?: string;
   modality?: string;
   degree_plan_url?: string;
   active?: boolean;
-  order?: number;
   curriculum?: unknown;
   characteristics?: unknown;
+  order?: number;
   createdAt: Date;
   updatedAt: Date;
   publishedAt: Date | null;
   bylines?: ContentBylineCredit[];
+  terms?: Record<string, TaxonomyTerm[]>;
 }
 
 export interface Page {
@@ -99,11 +104,11 @@ export interface Page {
   status: string;
   title: string;
   content?: PortableTextBlock[];
-  featured_image?: { id: string; src?: string; alt?: string; width?: number; height?: number };
   createdAt: Date;
   updatedAt: Date;
   publishedAt: Date | null;
   bylines?: ContentBylineCredit[];
+  terms?: Record<string, TaxonomyTerm[]>;
 }
 
 export interface Post {
@@ -111,21 +116,22 @@ export interface Post {
   slug: string | null;
   status: string;
   title: string;
-  featured_image?: { id: string; src?: string; alt?: string; width?: number; height?: number };
-  content?: PortableTextBlock[];
+  featured_image?: { id: string; src?: string; alt?: string; width?: number; height?: number; provider?: string; previewUrl?: string; meta?: Record<string, unknown> };
   excerpt?: string;
+  content?: PortableTextBlock[];
   fecha_publicacion?: string;
   createdAt: Date;
   updatedAt: Date;
   publishedAt: Date | null;
   bylines?: ContentBylineCredit[];
+  terms?: Record<string, TaxonomyTerm[]>;
 }
 
 declare module "emdash" {
   interface EmDashCollections {
-    announcements: Anuncios;
+    announcements: Announcement;
     aviso_destacado: AvisoDestacado;
-    library_collections: Acervo;
+    library_collections: LibraryCollection;
     licenciaturas: Licenciatura;
     maestrias: Maestria;
     pages: Page;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cut-2026",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "emdash": {

--- a/src/pages/congreso-2026.astro
+++ b/src/pages/congreso-2026.astro
@@ -23,7 +23,7 @@ export const prerender = false
 <meta name="theme-color" content="#060c1c">
 
 <style is:global>
-:root {
+.congreso {
   --bg:  #060c1c;
   --bg2: #0b1628;
   --bgc: #101d36;
@@ -45,12 +45,14 @@ export const prerender = false
   --da:  #b96b00;
   --dd:  #c4410a;
 }
-*,*::before,*::after { box-sizing:border-box; margin:0; padding:0; }
-html { scroll-behavior:smooth; }
-body { background:var(--bg); color:var(--cm); font-family:var(--san); font-size:16px; line-height:1.6; -webkit-font-smoothing:antialiased; }
-img { max-width:100%; display:block; }
-a { color:inherit; text-decoration:none; }
-em { font-style:italic; }
+.congreso *,
+.congreso *::before,
+.congreso *::after { box-sizing:border-box; margin:0; padding:0; }
+html:has(.congreso) { scroll-behavior:smooth; }
+.congreso { background:var(--bg); color:var(--cm); font-family:var(--san); font-size:16px; line-height:1.6; -webkit-font-smoothing:antialiased; }
+.congreso img { max-width:100%; display:block; }
+.congreso a { color:inherit; text-decoration:none; }
+.congreso em { font-style:italic; }
 
 /* ── NAV ── */
 .nav {
@@ -351,7 +353,7 @@ em { font-style:italic; }
 .reveal.d4 { transition-delay:.32s; }
 </style>
 </head>
-<body>
+<body class="congreso">
 
 <!-- NAV -->
 <nav class="nav" id="nav" aria-label="Navegación principal">


### PR DESCRIPTION
- Replace README with links to developer and editor docs
- Add docs/desarrolladores.md and docs/editores.md
- Fix congreso-2026 CSS scoped to .congreso class (was leaking global styles)
- Regenerate emdash-env.d.ts types (renamed interfaces, added TaxonomyTerm, expanded image types)
- Bump version to 1.0.1